### PR TITLE
Skiplist for comparison

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -4,11 +4,15 @@ var Benchmark = require('benchmark'),
     bsarray = require('./bsarray'),
     llrb = require('./llrb'),
     functionalRBTree = require('functional-red-black-tree'),
+    SkipList = require('./skiplist').SkipList,
     bintrees = require('bintrees');
     // not benchmarking dsjslib & binarySearchTree, they're slow and so not interesting
 
+console.log(SkipList);
+
 var data = [],
-    N = 1000;
+    N = 1000,
+    SKIP_LIST_HEIGHT = 16;
 
 for (var i = 0; i < N; i++) {
     data[i] = Math.floor(Math.random() * N);
@@ -25,6 +29,12 @@ new Benchmark.Suite()
     var tree = llrb(compare);
     for (var i = 0; i < N; i++) {
         tree.insert(data[i]);
+    }
+})
+.add('skiplist', function () {
+    var tree = new SkipList(SKIP_LIST_HEIGHT);
+    for (var i = 0; i < N; i++) {
+        tree.Put(data[i]);
     }
 })
 .add('bbtree', function () {
@@ -67,6 +77,11 @@ for (var i = 0; i < N; i++) {
     lltree.insert(data[i]);
 }
 
+var skiplist = new SkipList(SKIP_LIST_HEIGHT);
+for (var i = 0; i < N; i++) {
+    skiplist.Put(data[i]);
+}
+
 var rbtree = functionalRBTree(compare);
 for (var i = 0; i < N; i++) {
     rbtree = rbtree.insert(data[i]);
@@ -91,6 +106,11 @@ new Benchmark.Suite()
 .add('bbtree', function () {
     for (var i = 0; i < N; i++) {
         btree.find(data[i]);
+    }
+})
+.add('skiplist', function () {
+    for (var i = 0; i < N; i++) {
+        skiplist.Get(data[i]);
     }
 })
 .add('bsarray', function () {
@@ -130,6 +150,15 @@ new Benchmark.Suite()
     }
     for (i = 0; i < N; i++) {
         lltree.remove(data[i]);
+    }
+})
+.add('skiplist', function () {
+    var arr = new SkipList(SKIP_LIST_HEIGHT);
+    for (var i = 0; i < N; i++) {
+        arr.Put(data[i]);
+    }
+    for (var i = 0; i < N; i++) {
+        arr.Remove(data[i]);
     }
 })
 .add('bsarray', function () {

--- a/skiplist.js
+++ b/skiplist.js
@@ -1,0 +1,118 @@
+"use strict";
+exports.__esModule = true;
+var SkipListNode = /** @class */ (function () {
+    function SkipListNode() {
+    }
+    return SkipListNode;
+}());
+exports.SkipListNode = SkipListNode;
+var SkipList = /** @class */ (function () {
+    function SkipList(maxHeight) {
+        this.Head = new SkipListNode();
+        this.Head.Pointers = new Array(maxHeight);
+        this.height = maxHeight;
+    }
+    SkipList.prototype.Put = function (key, val) {
+        var newNodeHeight = randHeight(this.height);
+        var newNode = new SkipListNode();
+        newNode.Pointers = new Array(newNodeHeight);
+        newNode.Key = key;
+        newNode.Val = val;
+        var node = this.Head;
+        for (var i = this.height; i > 0; i--) {
+            var indexNew = newNode.Pointers.length - i;
+            var ptrs = node.Pointers;
+            var indexTest = ptrs.length - i;
+            var nodeTest = ptrs[indexTest];
+            while (nodeTest && nodeTest.Key <= key) {
+                node = nodeTest;
+                ptrs = node.Pointers;
+                indexTest = ptrs.length - i;
+                nodeTest = ptrs[indexTest];
+            }
+            if (i <= newNodeHeight) {
+                newNode.Pointers[indexNew] = ptrs[indexTest];
+                ptrs[indexTest] = newNode;
+            }
+        }
+        return newNode;
+    };
+    SkipList.prototype.Remove = function (toRemove) {
+        var key = toRemove.Key;
+        var removed = false;
+        var node = this.Head;
+        for (var i = this.height; i > 0; i--) {
+            var ptrs = node.Pointers;
+            var indexTest = ptrs.length - i;
+            var nodeTest = ptrs[indexTest];
+            while (nodeTest && nodeTest.Key < key) {
+                node = nodeTest;
+                ptrs = node.Pointers;
+                indexTest = ptrs.length - i;
+                nodeTest = ptrs[indexTest];
+            }
+            // update pointer while handling duplicates
+            if (nodeTest && nodeTest.Key == key) {
+                var dupNode = node;
+                var dupPtrs = dupNode.Pointers;
+                var dupNodeTest = nodeTest;
+                while (dupNodeTest && dupNodeTest.Key == key && dupNodeTest != toRemove) {
+                    dupNode = dupNodeTest;
+                    dupPtrs = dupNode.Pointers;
+                    indexTest = dupPtrs.length - i;
+                    dupNodeTest = dupPtrs[indexTest];
+                }
+                if (dupNodeTest == toRemove) {
+                    var removedNext = toRemove.Pointers.length - i;
+                    dupNode.Pointers[indexTest] = toRemove.Pointers[removedNext];
+                    removed = true;
+                }
+            }
+        }
+        return removed;
+    };
+    SkipList.prototype.Get = function (key) {
+        var node = this.Head;
+        for (var i = this.height; i > 0; i--) {
+            var ptrs = node.Pointers;
+            var indexTest = ptrs.length - i;
+            var nodeTest = ptrs[indexTest];
+            while (nodeTest && nodeTest.Key <= key) {
+                node = nodeTest;
+                ptrs = node.Pointers;
+                indexTest = ptrs.length - i;
+                nodeTest = ptrs[indexTest];
+            }
+        }
+        return node;
+    };
+    SkipList.prototype.Dump = function () {
+        for (var i = this.height - 1; i >= 0; i--) {
+            var vals = [];
+            for (var _i = 0, _a = this.ToSliceAtHeight(i); _i < _a.length; _i++) {
+                var v = _a[_i];
+                vals.push(v.Key);
+            }
+            console.log("Height:", i, "Count:", vals.length, vals);
+        }
+    };
+    SkipList.prototype.ToSlice = function () {
+        return this.ToSliceAtHeight(0);
+    };
+    SkipList.prototype.ToSliceAtHeight = function (height) {
+        var res = [];
+        var node = this.Head.Pointers[this.height - 1 - height];
+        while (node) {
+            res.push(node);
+            node = node.Pointers[node.Pointers.length - 1 - height];
+        }
+        return res;
+    };
+    return SkipList;
+}());
+exports.SkipList = SkipList;
+function randHeight(maxHeight) {
+    var h = 1;
+    for (; Math.random() <= 0.5 && h < maxHeight; h++) { }
+    return h;
+}

--- a/skiplist.ts
+++ b/skiplist.ts
@@ -1,0 +1,135 @@
+export class SkipListNode {
+	Pointers: SkipListNode[];
+	Key:      number
+	Val:      any
+}
+
+export class SkipList {
+	readonly Head: SkipListNode
+    private readonly height: number;
+
+    constructor(maxHeight: number) {
+        this.Head = new SkipListNode();
+        this.Head.Pointers = new Array(maxHeight);
+        this.height = maxHeight;
+    }
+
+    Put(key: number, val: any): SkipListNode {
+        const newNodeHeight = randHeight(this.height);
+
+        const newNode = new SkipListNode();
+        newNode.Pointers = new Array(newNodeHeight);
+        newNode.Key = key;
+        newNode.Val = val;
+
+        let node = this.Head;
+        for (let i = this.height; i > 0; i--) {
+            let indexNew = newNode.Pointers.length - i;
+            let ptrs = node.Pointers;
+            let indexTest = ptrs.length - i;
+            let nodeTest = ptrs[indexTest];
+
+            while (nodeTest && nodeTest.Key <= key) {
+                node = nodeTest;
+                ptrs = node.Pointers;
+                indexTest = ptrs.length - i;
+                nodeTest = ptrs[indexTest];
+            }
+
+            if (i <= newNodeHeight) {
+                newNode.Pointers[indexNew] = ptrs[indexTest];
+                ptrs[indexTest] = newNode
+            }
+        }
+
+        return newNode
+    }
+
+    Remove(toRemove: SkipListNode): boolean {
+        let key = toRemove.Key;
+        let removed = false;
+        let node = this.Head;
+        for (let i = this.height; i > 0; i--) {
+            let ptrs = node.Pointers;
+            let indexTest = ptrs.length - i;
+            let nodeTest = ptrs[indexTest];
+
+            while (nodeTest && nodeTest.Key < key) {
+                node = nodeTest;
+                ptrs = node.Pointers;
+                indexTest = ptrs.length - i;
+                nodeTest = ptrs[indexTest];
+            }
+
+            // update pointer while handling duplicates
+            if (nodeTest && nodeTest.Key == key) {
+                let dupNode = node;
+                let dupPtrs = dupNode.Pointers;
+                let dupNodeTest = nodeTest;
+                while (dupNodeTest && dupNodeTest.Key == key && dupNodeTest != toRemove) {
+                    dupNode = dupNodeTest;
+                    dupPtrs = dupNode.Pointers;
+                    indexTest = dupPtrs.length - i;
+                    dupNodeTest = dupPtrs[indexTest];
+                }
+
+                if (dupNodeTest == toRemove) {
+                    let removedNext = toRemove.Pointers.length - i;
+                    dupNode.Pointers[indexTest] = toRemove.Pointers[removedNext];
+                    removed = true;
+                }
+            }
+        }
+
+        return removed
+    }
+
+    Get(key: number): SkipListNode {
+        let node = this.Head;
+
+        for (let i = this.height; i > 0; i--) {
+            let ptrs = node.Pointers;
+            let indexTest = ptrs.length - i;
+            let nodeTest = ptrs[indexTest];
+
+            while (nodeTest && nodeTest.Key <= key) {
+                node = nodeTest;
+                ptrs = node.Pointers;
+                indexTest = ptrs.length - i;
+                nodeTest = ptrs[indexTest];
+            }
+        }
+
+        return node
+    }
+
+    Dump() {
+        for (let i = this.height - 1; i >= 0; i--) {
+            let vals = [];
+            for (let v of this.ToSliceAtHeight(i)) {
+                vals.push( v.Key );
+            }
+            console.log("Height:", i, "Count:", vals.length, vals);
+        }
+    }
+
+    ToSlice(): SkipListNode[] {
+        return this.ToSliceAtHeight(0);
+    }
+
+    ToSliceAtHeight(height: number): SkipListNode[] {
+        let res = [];
+        let node = this.Head.Pointers[this.height-1-height];
+        while (node) {
+            res.push(node);
+            node = node.Pointers[node.Pointers.length-1-height];
+        }
+        return res;
+    }
+}
+
+function randHeight(maxHeight: number): number {
+	let h = 1;
+	for (; Math.random() <= 0.5 && h < maxHeight; h++) {}
+	return h
+}


### PR DESCRIPTION
For comparison's sake, I implemented a skiplist and and added to the benchmark. The results were not so impressive. Implementation difficulty, however, was low. 

Feel free to close this PR. I thought folks might find it interesting as I have not seen many benchmarks comparing skip lists and balanced binary trees.

FYI, the implementation closely matches my Go implementation: https://github.com/pboyer/skiplist

```
λ tsc skiplist.ts && node bench.js
insert 1000 items:
llrb x 6,027 ops/sec ±1.23% (93 runs sampled)
skiplist x 2,722 ops/sec ±1.42% (91 runs sampled)
bbtree x 8,255 ops/sec ±1.27% (92 runs sampled)
bsarray x 6,344 ops/sec ±1.41% (96 runs sampled)
functional-red-black-tree x 2,835 ops/sec ±1.16% (95 runs sampled)
jsbintrees RBTree x 4,776 ops/sec ±1.17% (95 runs sampled)

search each item in 1000-sized tree
llrb x 20,908 ops/sec ±1.33% (92 runs sampled)
bbtree x 20,006 ops/sec ±1.29% (91 runs sampled)
skiplist x 5,786 ops/sec ±1.16% (91 runs sampled)
bsarray x 15,820 ops/sec ±0.95% (91 runs sampled)
functional-red-black-tree x 18,093 ops/sec ±0.89% (92 runs sampled)
jsbintrees RBTree x 17,964 ops/sec ±0.95% (90 runs sampled)
naive loop x 917 ops/sec ±0.95% (96 runs sampled)

insert 1000 items and then remove one by one
llrb x 1,828 ops/sec ±0.89% (95 runs sampled)
skiplist x 1,818 ops/sec ±0.95% (96 runs sampled)
bsarray x 3,154 ops/sec ±1.05% (94 runs sampled)
functional-red-black-tree x 1,264 ops/sec ±1.05% (95 runs sampled)
jsbintrees RBTree x 2,403 ops/sec ±0.81% (96 runs sampled)
```